### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 ![](http://lozano-hemmer.com/ss/33q.png)
-#Best practices for conservation of media art from an artist’s perspective
+# Best practices for conservation of media art from an artist’s perspective
 
 [RAFAEL LOZANO-HEMMER](http://lozano-hemmer.com) · SEPTEMBER 28, 2015
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
